### PR TITLE
closes #24 Add user ability to view orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,9 @@
 class OrdersController < ApplicationController
   def index
-    @orders = current_user.orders if current_user
+    if current_user
+      @orders = current_user.orders
+    else
+      render file: "public/404"
+    end
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,2 @@
+<h3>"So your dryer played you! You've come to the right place."</h3>
+<%= button_to "Orders", orders_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,2 @@
-<h3>"So your dryer played you! You've come to the right place."</h3>
-<%= button_to "Orders", orders_path %>
+<h3>So your dryer played you! You've come to the right place.</h3>
+<%= button_to "Orders", orders_path, method: :get %>

--- a/spec/features/visitor_can_create_account_and_get_to_their_dashboard_spec.rb
+++ b/spec/features/visitor_can_create_account_and_get_to_their_dashboard_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "visitor creates an account" do
-  pending
   context "with valid attributes" do
     scenario "visitor creates new account and is redirected" do
       visit login_path
@@ -17,9 +16,10 @@ RSpec.feature "visitor creates an account" do
 
       within "nav" do
         expect(page).to have_content("Logged in as Bob")
-        #expect page to have profile information!
       end
 
+      expect(page).to have_button("Orders")
+      expect(page).to have_content("So your dryer played you! You've come to the right place.")
       expect(page).to_not have_content("Login")
       expect(page).to have_content("Logout")
     end

--- a/spec/features/visitor_on_root_page_can_login_or_create_account_spec.rb
+++ b/spec/features/visitor_on_root_page_can_login_or_create_account_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.feature "visitor sees login and new account links" do
   scenario "visitor visits root page" do
-    pending
     visit "/"
 
     expect(page).to have_link("Login")
@@ -10,8 +9,8 @@ RSpec.feature "visitor sees login and new account links" do
 
     expect(current_path).to eq("/login")
 
-    expect(page).to have_content("username")
-    expect(page).to have_content("password")
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Password")
 
     expect(page).to have_link("Create Account")
   end


### PR DESCRIPTION
A user can view their past orders only when logged in by visiting their orders route