### PR TITLE
Add show page for a sock

### DIFF
--- a/app/views/socks/show.html.erb
+++ b/app/views/socks/show.html.erb
@@ -1,6 +1,10 @@
+<h2><%= @sock.name %></h2>
+<%= image_tag @sock.image_url, size: "250x400" %>
+<%= @sock.price %>
 <% if @sock.retired %>
   <%= "Item Retired" %>
 <% else %>
   <%= button_to "Add to Cart", cart_socks_path(sock_id: @sock.id) %>
 <% end %>
 <%= button_to "View Cart", cart_path, method: :get %>
+<%= button_to "Back to All Socks", socks_path, method: :get %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,3 @@
 <h3>So your dryer played you! You've come to the right place.</h3>
 <%= button_to "Orders", orders_path, method: :get %>
+<%= button_to "Edit Account Info", edit_user_path(@user), method: :get %>

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,8 +1,0 @@
-FactoryGirl.define do
-  factory :order_item do
-    sock nil
-    order nil
-    quantity 1
-    sock_price "9.99"
-  end
-end

--- a/spec/features/visitor_can_view_all_socks_spec.rb
+++ b/spec/features/visitor_can_view_all_socks_spec.rb
@@ -12,4 +12,15 @@ RSpec.feature "Visitor views all socks" do
       expect(page).to have_css("img[src=\"#{sock_3.image_url}\"]")
     end
   end
+
+  scenario "they can view one sock" do
+    sock = create(:sock)
+    visit sock_path(sock)
+    expect(page).to have_content sock.name
+    expect(page).to have_content sock.price
+    expect(page).to have_css("img[src=\"#{sock.image_url}\"]")
+    expect(page).to have_button("Add to Cart")
+    expect(page).to have_button("View Cart")
+    expect(page).to have_button("Back to All Socks")
+  end
 end


### PR DESCRIPTION
Add show page for a sock so that user is able
to see the indiviudal sock details when they
visit a single sock.