### PR TITLE
closes #87 Add ability of admin to view all socks

### DIFF
--- a/app/controllers/admin/socks_controller.rb
+++ b/app/controllers/admin/socks_controller.rb
@@ -1,0 +1,5 @@
+class Admin::SocksController < Admin::BaseController
+  def index
+    @socks = Sock.all
+  end
+end

--- a/app/models/sock.rb
+++ b/app/models/sock.rb
@@ -10,4 +10,12 @@ class Sock < ActiveRecord::Base
   validates :style_id, presence: true
   validates :category_id, presence: true
   validates :size_id, presence: true
+
+  def status
+    if retired
+      "#{name.capitalize} is retired"
+    else
+      "#{name.capitalize} is currently available for purchase"
+    end
+  end
 end

--- a/app/views/admin/socks/index.html.erb
+++ b/app/views/admin/socks/index.html.erb
@@ -1,0 +1,20 @@
+<table id="sock-table">
+  <tr>
+    <th>Sock Name</th>
+    <th>Sock Descriptors</th>
+    <th>Price</th>
+    <th>Status</th>
+    <th>Image</th>
+    <th>Actions</th>
+  </tr>
+  <% @socks.each do |sock| %>
+    <tr>
+    <td><%= sock.name %></td>
+    <td><%= "#{sock.category.title}, #{sock.foot}, #{sock.style.name}, #{sock.size.value}" %></td>
+    <td><%= number_to_currency(sock.price) %></td>
+    <td><%= sock.status %></td>
+    <td><%= image_tag sock.image_url, size: "100x150" %></td>
+    <td><%= link_to "Edit", edit_admin_sock_path(sock) %> <%= link_to "Delete", admin_sock_path(sock), method: :delete %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,2 +1,3 @@
 <h1>Admin Dashboard</h1>
 <%= button_to "Edit Account Info", edit_user_path(@admin), method: :get %>
+<%= button_to "View All Socks", admin_socks_path, method: :get %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get "/dashboard", to: "users#show"
+    resources :socks, only: [:index, :edit, :delete, :show]
   end
 
   get "/:id", to: "navigations#show"

--- a/spec/features/admin_views_socks_spec.rb
+++ b/spec/features/admin_views_socks_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Admin can see all items" do
+  scenario "admin can view all items in the sock store" do
+    admin = User.create(name: "bob",
+                        username: "adminbob",
+                        password: "password",
+                        role: 1)
+    sock_1, sock_2, sock_3 = create_list(:sock, 3)
+    sock_3.update_attributes(retired: true)
+
+    login(admin)
+
+    visit "/admin/dashboard"
+    expect(page).to have_button("View All Socks")
+    click_button "View All Socks"
+
+    expect(current_path).to eq("/admin/socks")
+    within "#sock-table" do
+      expect(page).to have_content(sock_1.name)
+      expect(page).to have_css("img[src=\"#{sock_2.image_url}\"]")
+      expect(page).to have_content(sock_3.name)
+      expect(page).to have_content("#{sock_3.name} is retired")
+      expect(page).to have_link("Edit")
+      expect(page).to have_link("Delete")
+    end
+  end
+end


### PR DESCRIPTION
Admin has ability to view information on all
socks within the store including retired socks
Admin has links to edit or delete a sock from
the all socks table. Admin sees sock information
for all socks within the table.